### PR TITLE
[codex] add connector input type

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ agent:
 
 A document should define only one of these root keys.
 
+## Connector inputs
+
+Connector inputs model runtime resource binding without making workflow scope
+part of the workflow schema. `allowedScopes` limits the connector scopes the
+caller may bind at runtime.
+
+```yaml
+workflow:
+  inputs:
+    connector:
+      type: connector
+      required: true
+      allowedScopes:
+        - account
+        - org
+  steps:
+    - run: echo using ${{ inputs.connector }}
+```
+
 ## Root steps
 
 Stages are optional. If `steps` is defined directly under the workflow, those

--- a/dist/schema.json
+++ b/dist/schema.json
@@ -772,6 +772,19 @@
     },
     "Input": {
       "properties": {
+        "allowedScopes": {
+          "description": "AllowedScopes constrains the scopes from which a runtime resource binding can select a connector.",
+          "items": {
+            "enum": [
+              "system",
+              "account",
+              "org",
+              "project"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
         "autofocus": {
           "description": "Autofocus configures the form element autofocus attribute.",
           "type": "boolean"
@@ -831,6 +844,7 @@
             "duration",
             "choice",
             "environment",
+            "connector",
             "secret",
             "step",
             "object"

--- a/samples/workflow-connector-input.yaml
+++ b/samples/workflow-connector-input.yaml
@@ -1,0 +1,11 @@
+# connector inputs bind scoped resources at runtime
+workflow:
+  inputs:
+    connector:
+      type: connector
+      required: true
+      allowedScopes:
+        - account
+        - org
+  steps:
+    - run: echo ${{ inputs.connector }}

--- a/schema/input.ts
+++ b/schema/input.ts
@@ -14,9 +14,16 @@ export interface Input {
       | "duration"
       | "choice"      // GitHub compatibility
       | "environment" // GitHub compatibility
+      | "connector"
       | "secret"
       | "step"
       | "object"
+
+    /**
+     * AllowedScopes constrains the scopes from which a runtime
+     * resource binding can select a connector.
+     */
+    allowedScopes?: ("system" | "account" | "org" | "project")[];
 
     /**
      * Description defines the input description.

--- a/yaml/input.go
+++ b/yaml/input.go
@@ -17,17 +17,18 @@
 package yaml
 
 type Input struct {
-	Autofocus   bool        `json:"autofocus,omitempty"`
-	Component   string      `json:"component,omitempty"`
-	Default     interface{} `json:"default,omitempty"`
-	Description string      `json:"description,omitempty"`
-	Enum        interface{} `json:"enum,omitempty"`
-	Items       interface{} `json:"items,omitempty"`
-	Mask        bool        `json:"mask,omitempty"`
-	Options     interface{} `json:"options,omitempty"`
-	Pattern     string      `json:"pattern,omitempty"`
-	Placeholder string      `json:"placeholder,omitempty"`
-	Required    bool        `json:"required,omitempty"`
-	Tooltip     string      `json:"tooltip,omitempty"`
-	Type        string      `json:"type,omitempty"`
+	AllowedScopes []string    `json:"allowedScopes,omitempty"`
+	Autofocus     bool        `json:"autofocus,omitempty"`
+	Component     string      `json:"component,omitempty"`
+	Default       interface{} `json:"default,omitempty"`
+	Description   string      `json:"description,omitempty"`
+	Enum          interface{} `json:"enum,omitempty"`
+	Items         interface{} `json:"items,omitempty"`
+	Mask          bool        `json:"mask,omitempty"`
+	Options       interface{} `json:"options,omitempty"`
+	Pattern       string      `json:"pattern,omitempty"`
+	Placeholder   string      `json:"placeholder,omitempty"`
+	Required      bool        `json:"required,omitempty"`
+	Tooltip       string      `json:"tooltip,omitempty"`
+	Type          string      `json:"type,omitempty"`
 }

--- a/yaml/parse_test.go
+++ b/yaml/parse_test.go
@@ -109,6 +109,43 @@ pipeline:
 	}
 }
 
+func TestParseConnectorInputAllowedScopes(t *testing.T) {
+	out, err := ParseString(`
+workflow:
+  inputs:
+    connector:
+      type: connector
+      required: true
+      allowedScopes:
+        - account
+        - org
+  steps:
+    - run: echo hello
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workflow, _, err := out.CanonicalWorkflow()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workflow == nil {
+		t.Fatal("expected canonical workflow")
+	}
+
+	connector := workflow.Inputs["connector"]
+	if connector == nil {
+		t.Fatal("expected connector input")
+	}
+	if got, want := connector.Type, "connector"; got != want {
+		t.Fatalf("got input type %q, want %q", got, want)
+	}
+	if got, want := connector.AllowedScopes, []string{"account", "org"}; !cmp.Equal(got, want) {
+		t.Fatalf("got allowed scopes %v, want %v", got, want)
+	}
+}
+
 func TestNormalizedWorkflowRootSteps(t *testing.T) {
 	out, err := ParseString(`
 workflow:


### PR DESCRIPTION
## Summary
- add `connector` as an input type
- add `allowedScopes` to constrain runtime connector binding
- document connector inputs as runtime resource binding, keeping workflow scope out of YAML
- add a sample and parser test for connector inputs with allowed scopes
- regenerate `dist/schema.json` and update the checked-in Go input struct

## Stacked On
- bradrydzewski/spec#21

## Validation
- `npm run schema`
- `npm run golang` after creating `dist/go` for generator output validation
- `go test ./yaml -run 'TestParseWorkflowAliases|TestParseWorkflowAliasConflict|TestParseConnectorInputAllowedScopes|TestNormalizedWorkflowRootSteps'`
- `git diff --check`